### PR TITLE
Fix missing catch block in renderNextBadgeProgress

### DIFF
--- a/public/render.js
+++ b/public/render.js
@@ -327,12 +327,8 @@ class Renderer {
                 container.innerHTML = '';
                 return;
             }
-        }
-        } catch (err) {
-    console.error('Error getting next badge:', err);
-    container.innerHTML = '';
-}
-        container.innerHTML = `
+
+            container.innerHTML = `
             <div class="bg-gradient-to-r from-purple-50 to-pink-50 rounded-xl p-6 mb-6 shadow-sm border border-purple-200">
                 <div class="flex items-center justify-between mb-4">
                     <div>
@@ -349,6 +345,10 @@ class Renderer {
                 <p class="text-xs text-gray-500 mt-2">Current streak: ${nextBadge.currentStreak} days</p>
             </div>
         `;
+        } catch (err) {
+            console.error('Error getting next badge:', err);
+            container.innerHTML = '';
+        }
     }
     
     updateModalGoals() {


### PR DESCRIPTION
## Summary
- fix placement of catch block in `Renderer.renderNextBadgeProgress`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d4da83b488325874c96ab2644f42a