### PR TITLE
Fix dashboard challenge progress calls

### DIFF
--- a/public/render.js
+++ b/public/render.js
@@ -43,8 +43,8 @@ class Renderer {
     renderDashboard() {
         const todayPoints = this.app.progressManager.getTodayPoints();
         const completion = this.app.progressManager.getCompletionPercentage();
-        const challengeDay = this.app.progressManager.getCurrentChallengeDay();
-        const challengeProgress = this.app.progressManager.getChallengeProgress();
+        const challengeDay = this.app.challengeManager.getCurrentChallengeDay();
+        const challengeProgress = this.app.challengeManager.getChallengeProgress();
         
         const challengeDaysText = challengeDay > 0 ? 
             `${challengeDay}` : 


### PR DESCRIPTION
## Summary
- update renderDashboard to use challengeManager's progress methods

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685d4daf89408325a6654894f3c3189f