### PR TITLE
Fix daily progress initialization

### DIFF
--- a/public/modals.js
+++ b/public/modals.js
@@ -123,7 +123,7 @@ class ModalManager {
                     this.app.challenges.push(challenge);
                     this.app.activeChallenge = challenge;
                     this.hideCreateChallengeModal();
-                    await this.app.initTodayProgress();
+                    await this.app.progressManager.initTodayProgress();
                     this.app.render();
                 }
             } catch (err) {


### PR DESCRIPTION
## Summary
- initialize today's progress via `progressManager` when creating challenge

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d4db1d0d48325874308d357aeaa08